### PR TITLE
Display code coverage on CI

### DIFF
--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -6,3 +6,10 @@ set -ex
 
 mvn clean verify
 
+# don't be so talkative ;)
+set +x
+
+echo "Code coverage report BEGIN"
+cd target/site/jacoco
+cat jacoco.csv
+echo "Code coverage report END"

--- a/pom.xml
+++ b/pom.xml
@@ -117,14 +117,20 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <skip>${maven.test.skip}</skip>
+          <output>file</output>
+          <append>true</append>
+        </configuration>
         <executions>
           <execution>
+            <id>jacoco-initialize</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
-          <id>report</id>
+            <id>report</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>


### PR DESCRIPTION
We'd need to have the code coverage displayed (in ANY useful form) in CI logs, so we can handle it w/o the need to use artefacts.

An example of consumable output:
```
Code coverage report BEGIN
GROUP,PACKAGE,CLASS,INSTRUCTION_MISSED,INSTRUCTION_COVERED,BRANCH_MISSED,BRANCH_COVERED,LINE_MISSED,LINE_COVERED,COMPLEXITY_MISSED,COMPLEXITY_COVERED,METHOD_MISSED,METHOD_COVERED
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,User,4,6,0,0,2,3,1,2,1,2
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,Bayesian,435,432,89,37,18,81,65,11,3,10
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,BayesianAnalysisStep,4,16,0,0,1,6,1,4,1,4
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,BayesianStepResponse,25,26,0,0,11,8,7,3,7,3
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,DnsFiddler,28,24,3,1,6,6,3,2,1,2
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,BayesianResponse,18,6,0,0,8,2,5,2,5,2
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,User.Attributes,4,6,0,0,2,2,1,2,1,2
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,Utils,31,126,6,10,9,35,6,8,1,5
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,BayesianAnalysisStep.DescriptorImpl,0,23,0,0,0,4,0,4,0,4
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,Utils.new ArrayList() {...},0,7,0,0,0,3,0,1,0,1
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,BayesianAnalysisStep.Execution,33,67,3,3,8,17,3,2,0,2
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,BayesianException,13,0,0,0,6,0,3,0,3,0
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,Utils.new ArrayList() {...},0,11,0,0,0,4,0,1,0,1
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,Utils.new ArrayList() {...},0,7,0,0,0,3,0,1,0,1
Bayesian Plugin,com.redhat.jenkins.plugins.bayesian,User.Data,8,6,0,0,3,2,2,2,2,2
Code coverage report END
```